### PR TITLE
Remove unnecessary `require` statement

### DIFF
--- a/ponyx.rb
+++ b/ponyx.rb
@@ -5,7 +5,6 @@ require 'dotenv'
 require 'logger'
 require 'roda'
 require 'sequel'
-require 'tilt'
 
 Dotenv.load
 


### PR DESCRIPTION
- `tilt` is a dependency of one of the roda plugins. And should be [required](https://github.com/jeremyevans/roda/blob/70516ec5757348e075210b1103942f4a1f434a28/lib/roda/plugins/render.rb#L3) by the plugin. There is no explicit usage of tilt in the source code.

- It will slightly improve performace